### PR TITLE
UICLAIM-23 Include global mod-settings permissions in base permission sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UICLAIM-19](https://issues.folio.org/browse/UICLAIM-19) *BREAKING* Update `orders` and `order-lines` interfaces to `13.0` and `4.0` accordingly.
 * [STCOM-1439](https://issues.folio.org/browse/STCOM-1439) Align results MCL cells to the flex start.
 * [UICLAIM-21](https://issues.folio.org/browse/UICLAIM-21) *BREAKING* Update for Split Search & Browse APIs.
+* [UICLAIM-23](https://issues.folio.org/browse/UICLAIM-23) Include global `mod-settings` permissions in base permission sets.
 
 ## [1.0.0](https://github.com/folio-org/ui-claims/tree/v1.0.0) (2025-03-12)
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,11 @@
     "permissionSets": [
       {
         "permissionName": "module.claims.enabled",
-        "displayName": "UI: Claims module is enabled"
+        "displayName": "UI: Claims module is enabled",
+        "subPermissions": [
+          "mod-settings.entries.collection.get",
+          "mod-settings.global.read.stripes-core.prefs.manage"
+        ]
       },
       {
         "permissionName": "ui-claims.claiming.view",


### PR DESCRIPTION
## Purpose
Added global permissions for get read-access to values such as tenant’s locale, timezone, and currency

## Refs
https://folio-org.atlassian.net/browse/UICLAIM-23