### PR TITLE
UICLAIM-26 Fix failing tests in Claiming.test.tsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [STCOM-1439](https://issues.folio.org/browse/STCOM-1439) Align results MCL cells to the flex start.
 * [UICLAIM-21](https://issues.folio.org/browse/UICLAIM-21) *BREAKING* Update for Split Search & Browse APIs.
 * [UICLAIM-23](https://issues.folio.org/browse/UICLAIM-23) Include global `stripes-core.settings.read` permission in base permission sets.
+* [UICLAIM-26](https://folio-org.atlassian.net/browse/UICLAIM-26) Fix failing tests in Claiming.test.tsx.
 
 ## [1.0.0](https://github.com/folio-org/ui-claims/tree/v1.0.0) (2025-03-12)
 

--- a/src/views/Claiming/Claiming.test.tsx
+++ b/src/views/Claiming/Claiming.test.tsx
@@ -22,6 +22,8 @@ import { useClaiming } from './hooks';
 
 jest.mock('@folio/stripes/smart-components', () => ({
   ...jest.requireActual('@folio/stripes/smart-components'),
+  // eslint-disable-next-line react/prop-types
+  PersistedPaneset: (props: { children: React.ReactNode }) => <div>{props.children}</div>,
   useCustomFields: jest.fn(() => ([[]])),
 }));
 jest.mock('@folio/stripes-acq-components', () => ({
@@ -49,8 +51,6 @@ jest.mock('./hooks', () => ({
   ...jest.requireActual('./hooks'),
   useClaiming: jest.fn(),
 }));
-
-const FORMAT = 'MM/DD/YYYY';
 
 const renderComponent = (props = {}) => render(
   <Claiming {...props} />,
@@ -124,13 +124,13 @@ describe('Claiming', () => {
 
       expect(screen.getByText('stripes-acq-components.claiming.modal.sendClaim.heading')).toBeInTheDocument();
 
-      /* Fill the form */
-      await act(async () => {
-        await userEvent.type(screen.getByRole('textbox', { name: 'stripes-acq-components.claiming.modal.sendClaim.field.claimExpiryDate' }), dayjs().add(5, 'days').format(FORMAT));
-      });
-      await act(async () => {
-        await userEvent.click(screen.getByRole('button', { name: 'stripes-acq-components.FormFooter.save' }));
-      });
+      /* Fill the form - use the Datepicker's placeholder as the format
+         to be locale-independent (the Datepicker derives its format from the system locale) */
+      const sendDateInput = screen.getByRole('textbox', { name: 'stripes-acq-components.claiming.modal.sendClaim.field.claimExpiryDate' });
+      const sendDateFormat = (sendDateInput as HTMLInputElement).placeholder;
+
+      await userEvent.type(sendDateInput, dayjs().add(5, 'days').format(sendDateFormat));
+      await userEvent.click(screen.getByRole('button', { name: 'stripes-acq-components.FormFooter.save' }));
 
       expect(sendClaims).toHaveBeenCalled();
     });
@@ -159,13 +159,12 @@ describe('Claiming', () => {
 
       expect(screen.getByText('stripes-acq-components.claiming.modal.delayClaim.heading')).toBeInTheDocument();
 
-      /* Fill the form */
-      await act(async () => {
-        await userEvent.type(screen.getByRole('textbox', { name: 'stripes-acq-components.claiming.modal.delayClaim.field.delayTo' }), dayjs().add(5, 'days').format(FORMAT));
-      });
-      await act(async () => {
-        await userEvent.click(screen.getByRole('button', { name: 'stripes-acq-components.FormFooter.save' }));
-      });
+      /* Fill the form - use the Datepicker's placeholder as the format */
+      const delayDateInput = screen.getByRole('textbox', { name: 'stripes-acq-components.claiming.modal.delayClaim.field.delayTo' });
+      const delayDateFormat = (delayDateInput as HTMLInputElement).placeholder;
+
+      await userEvent.type(delayDateInput, dayjs().add(5, 'days').format(delayDateFormat));
+      await userEvent.click(screen.getByRole('button', { name: 'stripes-acq-components.FormFooter.save' }));
 
       expect(delayClaims).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

Fix two issues in `Claiming.test.tsx` that cause all 5 render-dependent tests to fail:

- Add missing `PersistedPaneset` mock to the `@folio/stripes/smart-components` mock
  (matching the pattern used in ui-orders, ui-receiving, ui-invoice, and other ACQ modules)
- Replace hardcoded `MM/DD/YYYY` date format with locale-independent approach by reading
  the Datepicker's `placeholder` attribute

### Root cause

1. The `@folio/stripes-acq-components` jest setup mocks `@rehooks/local-storage` with a
   bare `jest.fn()` for `useLocalStorage` (returns `undefined`). `PersistedPaneset`
   destructures this return value and crashes with
   `TypeError: undefined is not iterable`.

2. The Datepicker derives its input format from the system locale. On non-US systems
   (e.g. German locale → `DD.MM.YYYY`), the hardcoded `MM/DD/YYYY` format is rejected
   by the input validator, preventing form submission.

Refs [UICLAIM-26](https://folio-org.atlassian.net/browse/UICLAIM-26)